### PR TITLE
Fix DhcpServiceInfo deprecation warning

### DIFF
--- a/custom_components/luxtronik/config_flow.py
+++ b/custom_components/luxtronik/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.dhcp import DhcpServiceInfo
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TIMEOUT, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult


### PR DESCRIPTION
## Summary
- fix deprecated DhcpServiceInfo import

## Testing
- `flake8 custom_components/luxtronik/config_flow.py` *(fails: line too long)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528cfb0fe0832b8ed1dad05e22a841