### PR TITLE
Handle connection drops gracefully

### DIFF
--- a/custom_components/luxtronik/lux_helper.py
+++ b/custom_components/luxtronik/lux_helper.py
@@ -213,6 +213,10 @@ class Luxtronik:
                 "Disconnected from Luxtronik heatpump %s:%s", self._host, self._port
             )
 
+    def disconnect(self):
+        """Public wrapper to close the socket connection."""
+        self._disconnect()
+
     def read(self):
         """Read data from heatpump."""
         self._read_write(write=False)


### PR DESCRIPTION
## Summary
- ensure coordinator disconnects client on communication errors so future updates reconnect
- expose a public `disconnect` method on the Luxtronik helper to close the socket

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a432d4874c832b812b1530d46c17f4