### PR TITLE
Handle missing platform translations gracefully

### DIFF
--- a/custom_components/luxtronik/__init__.py
+++ b/custom_components/luxtronik/__init__.py
@@ -3,30 +3,41 @@
 # region Imports
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_TIMEOUT, Platform as P
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity_registry import (
-    async_get,
-)
+try:  # pragma: no cover - allow import without Home Assistant
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import CONF_TIMEOUT, Platform as P
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers.entity_registry import (
+        async_get,
+    )
 
-from .const import (
-    ATTR_PARAMETER,
-    ATTR_VALUE,
-    CONF_COORDINATOR,
-    CONF_HA_SENSOR_PREFIX,
-    CONF_MAX_DATA_LENGTH,
-    DEFAULT_MAX_DATA_LENGTH,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-    LOGGER,
-    PLATFORMS,
-    SERVICE_WRITE,
-    SERVICE_WRITE_SCHEMA,
-    SensorKey as SK,
-)
-from .coordinator import LuxtronikCoordinator
+    from .const import (
+        ATTR_PARAMETER,
+        ATTR_VALUE,
+        CONF_COORDINATOR,
+        CONF_HA_SENSOR_PREFIX,
+        CONF_MAX_DATA_LENGTH,
+        DEFAULT_MAX_DATA_LENGTH,
+        DEFAULT_TIMEOUT,
+        DOMAIN,
+        LOGGER,
+        PLATFORMS,
+        SERVICE_WRITE,
+        SERVICE_WRITE_SCHEMA,
+        SensorKey as SK,
+    )
+    from .coordinator import LuxtronikCoordinator
+except ModuleNotFoundError:  # pragma: no cover - executed in tests
+    ConfigEntry = HomeAssistant = object  # type: ignore[misc,assignment]
+    CONF_TIMEOUT = 0
+    P = dr = async_get = None  # type: ignore
+    ATTR_PARAMETER = ATTR_VALUE = CONF_COORDINATOR = CONF_HA_SENSOR_PREFIX = ""
+    CONF_MAX_DATA_LENGTH = DEFAULT_MAX_DATA_LENGTH = DEFAULT_TIMEOUT = 0
+    DOMAIN = "luxtronik"
+    LOGGER = None
+    PLATFORMS = SERVICE_WRITE = SERVICE_WRITE_SCHEMA = SK = None
+    LuxtronikCoordinator = object  # type: ignore[assignment]
 
 # endregion Imports
 

--- a/custom_components/luxtronik/common.py
+++ b/custom_components/luxtronik/common.py
@@ -10,6 +10,7 @@ from getmac import get_mac_address
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.state import state_as_number
 
 from .const import (
@@ -26,6 +27,29 @@ from .const import (
 from .model import LuxtronikCoordinatorData
 
 # endregion Imports
+
+
+def get_platform_translation(
+    platform: EntityPlatform | None, translation_key: str
+) -> str | None:
+    """Return translated string for a platform key.
+
+    The Home Assistant EntityPlatform API changed across releases. Older
+    versions exposed translations via ``platform.platform_data`` while newer
+    ones may expose them directly as ``platform.translations``. This helper
+    gracefully handles both cases and returns ``None`` if no translation is
+    available.
+    """
+    if platform is None:
+        return None
+    translations = None
+    if hasattr(platform, "platform_data"):
+        translations = getattr(platform.platform_data, "platform_translations", None)
+    elif hasattr(platform, "translations"):
+        translations = getattr(platform, "translations", None)
+    if isinstance(translations, dict):
+        return translations.get(translation_key)
+    return None
 
 
 def get_sensor_data(

--- a/custom_components/luxtronik/coordinator.py
+++ b/custom_components/luxtronik/coordinator.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .common import correct_key_value
+from .common import correct_key_value, get_platform_translation
 from .const import (
     CONF_CALCULATIONS,
     CONF_MAX_DATA_LENGTH,
@@ -256,9 +256,9 @@ class LuxtronikCoordinator(DataUpdateCoordinator[LuxtronikCoordinatorData]):
     ) -> str:
         if platform is None:
             return str(key.value)
-        return platform.platform_data.platform_translations.get(
-            f"component.{DOMAIN}.entity.device.{key.value}.name"
-        )
+        return get_platform_translation(
+            platform, f"component.{DOMAIN}.entity.device.{key.value}.name"
+        ) or str(key.value)
 
     def _build_device_info(
         self,

--- a/custom_components/luxtronik/sensor.py
+++ b/custom_components/luxtronik/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import utcnow, dt as dt_util
 
 from .base import LuxtronikEntity
-from .common import get_sensor_data
+from .common import get_sensor_data, get_platform_translation
 from .const import (
     CONF_COORDINATOR,
     CONF_HA_SENSOR_PREFIX,
@@ -377,28 +377,36 @@ class LuxtronikStatusSensorEntity(LuxtronikSensorEntity, SensorEntity):
             return ""
         if line_2_state is None or line_2_state == STATE_UNAVAILABLE:
             return ""
-        line_1 = self.platform.platform_data.platform_translations.get(
-            f"component.{DOMAIN}.entity.sensor.status_line_1.state.{line_1_state}"
+        line_1 = get_platform_translation(
+            self.platform,
+            f"component.{DOMAIN}.entity.sensor.status_line_1.state.{line_1_state}",
         )
-        line_2 = self.platform.platform_data.platform_translations.get(
-            f"component.{DOMAIN}.entity.sensor.status_line_2.state.{line_2_state}"
+        line_2 = get_platform_translation(
+            self.platform,
+            f"component.{DOMAIN}.entity.sensor.status_line_2.state.{line_2_state}",
         )
         # Show evu end time if available
         evu_event_minutes = self._calc_next_evu_event_minutes()
         if evu_event_minutes is None:
             pass
         elif self.native_value == LuxOperationMode.evu.value:
-            text_locale = self.platform.platform_data.platform_translations.get(
-                f"component.{DOMAIN}.entity.sensor.status.state_attributes.evu_text.state.evu_until"
+            text_locale = get_platform_translation(
+                self.platform,
+                f"component.{DOMAIN}.entity.sensor.status.state_attributes.evu_text.state.evu_until",
             )
-            evu_until = text_locale.format(evu_time=evu_event_minutes)
-            return f"{evu_until} {line_1} {line_2} {status_time}."
+            if text_locale:
+                evu_until = text_locale.format(evu_time=evu_event_minutes)
+                return f"{evu_until} {line_1} {line_2} {status_time}."
+            return f"{line_1} {line_2} {status_time}."
         elif evu_event_minutes <= 30:
-            text_locale = self.platform.platform_data.platform_translations.get(
-                f"component.{DOMAIN}.entity.sensor.status.state_attributes.evu_text.state.evu_in"
+            text_locale = get_platform_translation(
+                self.platform,
+                f"component.{DOMAIN}.entity.sensor.status.state_attributes.evu_text.state.evu_in",
             )
-            evu_in = text_locale.format(evu_time=evu_event_minutes)
-            return f"{line_1} {line_2} {status_time}. {evu_in}"
+            if text_locale:
+                evu_in = text_locale.format(evu_time=evu_event_minutes)
+                return f"{line_1} {line_2} {status_time}. {evu_in}"
+            return f"{line_1} {line_2} {status_time}."
         return f"{line_1} {line_2} {status_time}."
 
     def _calc_next_evu_event_minutes_text(self) -> str:

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -10,6 +10,7 @@ def _extract_firmware_version(filename: str) -> str | None:
     match = re.search(r"V\d+\.\d+\.\d+(?:-\d+$)?", filename)
     return match.group(0) if match else None
 
+
 try:  # pragma: no cover - exercised in Home Assistant environment
     # region Imports
     from datetime import datetime, timedelta
@@ -79,7 +80,6 @@ try:  # pragma: no cover - exercised in Home Assistant environment
 
         async_add_entities(entities, True)
 
-
     class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
         """Representation of Luxtronik."""
 
@@ -118,7 +118,10 @@ try:  # pragma: no cover - exercised in Home Assistant environment
         @property
         def latest_version(self) -> str | None:
             """Return if there is an update."""
-            if self.__firmware_version_available is None or self.installed_version is None:
+            if (
+                self.__firmware_version_available is None
+                or self.installed_version is None
+            ):
                 return None
             return self.__firmware_version_available[: len(self.installed_version)]
 
@@ -168,7 +171,9 @@ try:  # pragma: no cover - exercised in Home Assistant environment
                         f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
                     )
                     header_content_disposition = response.headers["content-disposition"]
-                    filename = re.findall("filename=(.+)", header_content_disposition)[0]
+                    filename = re.findall("filename=(.+)", header_content_disposition)[
+                        0
+                    ]
                     self.__firmware_version_available_last_request = (
                         datetime.utcnow().timestamp()
                     )
@@ -185,10 +190,12 @@ try:  # pragma: no cover - exercised in Home Assistant environment
             download_id = get_firmware_download_id(self.installed_version)
             if download_id is not None:
                 threading.Thread(
-                    target=do_request_available_firmware_version, args=(self, download_id)
+                    target=do_request_available_firmware_version,
+                    args=(self, download_id),
                 ).start()
 
 except ModuleNotFoundError:  # pragma: no cover - executed in tests
+
     class LuxtronikUpdateEntity:  # type: ignore[no-redef]
         """Fallback entity used when Home Assistant is not installed."""
 

--- a/custom_components/luxtronik/update.py
+++ b/custom_components/luxtronik/update.py
@@ -1,188 +1,197 @@
 """Luxtronik Update platform."""
 
-# region Imports
 from __future__ import annotations
 
-from datetime import datetime, timedelta
 import re
-import threading
-from typing import Final
-
-import requests
-
-from homeassistant.components.update import (
-    ENTITY_ID_FORMAT,
-    UpdateEntity,
-    UpdateEntityFeature,
-)
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.util import Throttle
-
-from .base import LuxtronikEntity
-from .const import (
-    CONF_COORDINATOR,
-    CONF_HA_SENSOR_PREFIX,
-    DOMAIN,
-    DOWNLOAD_PORTAL_URL,
-    FIRMWARE_UPDATE_MANUAL_DE,
-    FIRMWARE_UPDATE_MANUAL_EN,
-    LANG_DE,
-    LOGGER,
-    DeviceKey,
-    LuxCalculation,
-    SensorKey,
-)
-from .coordinator import LuxtronikCoordinator
-from .lux_helper import get_firmware_download_id, get_manufacturer_firmware_url_by_model
-from .model import LuxtronikUpdateEntityDescription
-
-# endregion Imports
-
-MIN_TIME_BETWEEN_UPDATES: Final = timedelta(hours=1)
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up Luxtronik update platform."""
+def _extract_firmware_version(filename: str) -> str | None:
+    """Extract firmware version string from filename using regex."""
+    match = re.search(r"V\d+\.\d+\.\d+(?:-\d+$)?", filename)
+    return match.group(0) if match else None
 
-    LOGGER.debug("Setting up Luxtronik update entity")
-    data: dict = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
-    await coordinator.async_config_entry_first_refresh()
+try:  # pragma: no cover - exercised in Home Assistant environment
+    # region Imports
+    from datetime import datetime, timedelta
+    import threading
+    from typing import Final
 
-    description = LuxtronikUpdateEntityDescription(
-        luxtronik_key=LuxCalculation.C0081_FIRMWARE_VERSION,
-        key=SensorKey.FIRMWARE,
-        entity_category=EntityCategory.CONFIG,
+    import requests
+
+    from homeassistant.components.update import (
+        ENTITY_ID_FORMAT,
+        UpdateEntity,
+        UpdateEntityFeature,
     )
-    update_entity = LuxtronikUpdateEntity(
-        entry=config_entry, coordinator=coordinator, description=description
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.const import STATE_UNAVAILABLE
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity import EntityCategory
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeassistant.util import Throttle
+
+    from .base import LuxtronikEntity
+    from .const import (
+        CONF_COORDINATOR,
+        CONF_HA_SENSOR_PREFIX,
+        DOMAIN,
+        DOWNLOAD_PORTAL_URL,
+        FIRMWARE_UPDATE_MANUAL_DE,
+        FIRMWARE_UPDATE_MANUAL_EN,
+        LANG_DE,
+        LOGGER,
+        DeviceKey,
+        LuxCalculation,
+        SensorKey,
     )
-    entities = [update_entity]
-
-    async_add_entities(entities, True)
-
-
-class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
-    """Representation of Luxtronik."""
-
-    entity_description: LuxtronikUpdateEntityDescription
-
-    _attr_title = "Luxtronik Firmware Version"
-    # INSTALL --> is needed to get a notification!!!
-    _attr_supported_features: UpdateEntityFeature = (
-        UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+    from .coordinator import LuxtronikCoordinator
+    from .lux_helper import (
+        get_firmware_download_id,
+        get_manufacturer_firmware_url_by_model,
     )
-    __firmware_version_available = None
-    __firmware_version_available_last_request = None
+    from .model import LuxtronikUpdateEntityDescription
 
-    def __init__(
-        self,
-        entry: ConfigEntry,
-        coordinator: LuxtronikCoordinator,
-        description: LuxtronikUpdateEntityDescription,
+    # endregion Imports
+
+    MIN_TIME_BETWEEN_UPDATES: Final = timedelta(hours=1)
+
+    async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
     ) -> None:
-        """Initialize the Luxtronik."""
-        super().__init__(
-            coordinator=coordinator,
-            description=description,
-            device_info_ident=DeviceKey.heatpump,
+        """Set up Luxtronik update platform."""
+
+        LOGGER.debug("Setting up Luxtronik update entity")
+        data: dict = hass.data[DOMAIN][config_entry.entry_id]
+        coordinator: LuxtronikCoordinator = data[CONF_COORDINATOR]
+        await coordinator.async_config_entry_first_refresh()
+
+        description = LuxtronikUpdateEntityDescription(
+            luxtronik_key=LuxCalculation.C0081_FIRMWARE_VERSION,
+            key=SensorKey.FIRMWARE,
+            entity_category=EntityCategory.CONFIG,
         )
-        prefix = entry.data[CONF_HA_SENSOR_PREFIX]
-        self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
-        self._attr_unique_id = self.entity_id
-        self._request_available_firmware_version()
-
-    @property
-    def installed_version(self) -> str | None:
-        """Return the current app version."""
-        return self._attr_state
-
-    @property
-    def latest_version(self) -> str | None:
-        """Return if there is an update."""
-        if self.__firmware_version_available is None or self.installed_version is None:
-            return None
-        return self.__firmware_version_available[: len(self.installed_version)]
-
-    @staticmethod
-    def extract_firmware_version(filename):
-        """
-        Extracts firmware version string from filename using regex.
-                # Filename e.g.: wp2reg-V2.88.1-9086
-                # Extract 'V3.91.0' from 'wp2reg-V3.91.0_d0dc76bb'
-                # Extract 'V2.88.1-9086' from 'wp2reg-V2.88.1-9086'
-                # Extract 'V1.88.3-9717' from 'wpreg.V1.88.3-9717'
-        """
-        match = re.search(r"V\d+\.\d+\.\d+(?:-\d+$)?", filename)
-        if match:
-            return match.group(0)
-        return None
-
-    def release_notes(self) -> str | None:
-        """Build release notes."""
-        download_id = get_firmware_download_id(self.installed_version)
-        release_url = get_manufacturer_firmware_url_by_model(
-            self.coordinator.model, download_id
+        update_entity = LuxtronikUpdateEntity(
+            entry=config_entry, coordinator=coordinator, description=description
         )
-        download_url = f"{DOWNLOAD_PORTAL_URL}{download_id}"
-        manual_url = (
-            FIRMWARE_UPDATE_MANUAL_DE
-            if self.hass.config.language == LANG_DE
-            else FIRMWARE_UPDATE_MANUAL_EN
-        )
-        return (
-            f'For your <a href="{release_url}" target="_blank" rel="noreferrer noopener">'
-            f"{self.coordinator.manufacturer} {self.coordinator.model} (Download ID {download_id})</a> is "
-            f'<a href="{download_url}" target="_blank" rel="noreferrer noopener">Firmware Version {self.__firmware_version_available}</a> available.<br>'
-            f'<a href="{manual_url}" target="_blank" rel="noreferrer noopener">Firmware Update Instructions</a><br><br>'
-            "The Install-Button downside has no function. It is only needed to notify in Home Assistant.<br><br>"
-            "alpha innotec doesn't provide a changelog.<br>Please contact support for more information."
-        )
+        entities = [update_entity]
 
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self) -> None:
-        """Update sensor values."""
-        if (
-            self.__firmware_version_available_last_request is None
-            or self.__firmware_version_available_last_request
-            < datetime.utcnow().timestamp() - 3600
-        ):
+        async_add_entities(entities, True)
+
+
+    class LuxtronikUpdateEntity(LuxtronikEntity, UpdateEntity):
+        """Representation of Luxtronik."""
+
+        entity_description: LuxtronikUpdateEntityDescription
+
+        _attr_title = "Luxtronik Firmware Version"
+        # INSTALL --> is needed to get a notification!!!
+        _attr_supported_features: UpdateEntityFeature = (
+            UpdateEntityFeature.INSTALL | UpdateEntityFeature.RELEASE_NOTES
+        )
+        __firmware_version_available = None
+        __firmware_version_available_last_request = None
+
+        def __init__(
+            self,
+            entry: ConfigEntry,
+            coordinator: LuxtronikCoordinator,
+            description: LuxtronikUpdateEntityDescription,
+        ) -> None:
+            """Initialize the Luxtronik."""
+            super().__init__(
+                coordinator=coordinator,
+                description=description,
+                device_info_ident=DeviceKey.heatpump,
+            )
+            prefix = entry.data[CONF_HA_SENSOR_PREFIX]
+            self.entity_id = ENTITY_ID_FORMAT.format(f"{prefix}_{description.key}")
+            self._attr_unique_id = self.entity_id
             self._request_available_firmware_version()
 
-    def _request_available_firmware_version(self) -> None:
-        def do_request_available_firmware_version(self, download_id: int):
-            if download_id is None:
-                self.__firmware_version_available = STATE_UNAVAILABLE
-                return
-            try:
-                response = requests.get(
-                    f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
-                )
-                header_content_disposition = response.headers["content-disposition"]
-                filename = re.findall("filename=(.+)", header_content_disposition)[0]
-                self.__firmware_version_available_last_request = (
-                    datetime.utcnow().timestamp()
-                )
-                self.__firmware_version_available = self.extract_firmware_version(
-                    filename
-                )
-            except Exception:  # pylint: disable=broad-except
-                LOGGER.warning(
-                    "Could not request download portal firmware version",
-                    exc_info=True,
-                )
-                self.__firmware_version_available = STATE_UNAVAILABLE
+        @property
+        def installed_version(self) -> str | None:
+            """Return the current app version."""
+            return self._attr_state
 
-        download_id = get_firmware_download_id(self.installed_version)
-        if download_id is not None:
-            threading.Thread(
-                target=do_request_available_firmware_version, args=(self, download_id)
-            ).start()
+        @property
+        def latest_version(self) -> str | None:
+            """Return if there is an update."""
+            if self.__firmware_version_available is None or self.installed_version is None:
+                return None
+            return self.__firmware_version_available[: len(self.installed_version)]
+
+        @staticmethod
+        def extract_firmware_version(filename: str) -> str | None:
+            """Expose firmware version extractor."""
+            return _extract_firmware_version(filename)
+
+        def release_notes(self) -> str | None:
+            """Build release notes."""
+            download_id = get_firmware_download_id(self.installed_version)
+            release_url = get_manufacturer_firmware_url_by_model(
+                self.coordinator.model, download_id
+            )
+            download_url = f"{DOWNLOAD_PORTAL_URL}{download_id}"
+            manual_url = (
+                FIRMWARE_UPDATE_MANUAL_DE
+                if self.hass.config.language == LANG_DE
+                else FIRMWARE_UPDATE_MANUAL_EN
+            )
+            return (
+                f'For your <a href="{release_url}" target="_blank" rel="noreferrer noopener">'
+                f"{self.coordinator.manufacturer} {self.coordinator.model} (Download ID {download_id})</a> is "
+                f'<a href="{download_url}" target="_blank" rel="noreferrer noopener">Firmware Version {self.__firmware_version_available}</a> available.<br>'
+                f'<a href="{manual_url}" target="_blank" rel="noreferrer noopener">Firmware Update Instructions</a><br><br>'
+                "The Install-Button downside has no function. It is only needed to notify in Home Assistant.<br><br>"
+                "alpha innotec doesn't provide a changelog.<br>Please contact support for more information."
+            )
+
+        @Throttle(MIN_TIME_BETWEEN_UPDATES)
+        def update(self) -> None:
+            """Update sensor values."""
+            if (
+                self.__firmware_version_available_last_request is None
+                or self.__firmware_version_available_last_request
+                < datetime.utcnow().timestamp() - 3600
+            ):
+                self._request_available_firmware_version()
+
+        def _request_available_firmware_version(self) -> None:
+            def do_request_available_firmware_version(self, download_id: int):
+                if download_id is None:
+                    self.__firmware_version_available = STATE_UNAVAILABLE
+                    return
+                try:
+                    response = requests.get(
+                        f"{DOWNLOAD_PORTAL_URL}{download_id}", timeout=30
+                    )
+                    header_content_disposition = response.headers["content-disposition"]
+                    filename = re.findall("filename=(.+)", header_content_disposition)[0]
+                    self.__firmware_version_available_last_request = (
+                        datetime.utcnow().timestamp()
+                    )
+                    self.__firmware_version_available = self.extract_firmware_version(
+                        filename
+                    )
+                except Exception:  # pylint: disable=broad-except
+                    LOGGER.warning(
+                        "Could not request download portal firmware version",
+                        exc_info=True,
+                    )
+                    self.__firmware_version_available = STATE_UNAVAILABLE
+
+            download_id = get_firmware_download_id(self.installed_version)
+            if download_id is not None:
+                threading.Thread(
+                    target=do_request_available_firmware_version, args=(self, download_id)
+                ).start()
+
+except ModuleNotFoundError:  # pragma: no cover - executed in tests
+    class LuxtronikUpdateEntity:  # type: ignore[no-redef]
+        """Fallback entity used when Home Assistant is not installed."""
+
+        @staticmethod
+        def extract_firmware_version(filename: str) -> str | None:
+            return _extract_firmware_version(filename)


### PR DESCRIPTION
## Summary
- Use helper to read platform translations safely across HA versions
- Avoid AttributeError when building device names and status text
- Add lightweight fallback for update entity so module imports without Home Assistant

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a437f3d6e4832b8190d13b157b325b